### PR TITLE
Nullable type support on the code generator

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -7,11 +7,11 @@ jobs:
   gradle:
     runs-on: ubuntu-latest
     steps:
-      - timeout-minutes: 10
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
           java-version: 1.8
       - uses: eskatos/gradle-command-action@v1
+        timeout-minutes: 10
         with:
           arguments: build

--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -7,6 +7,7 @@ jobs:
   gradle:
     runs-on: ubuntu-latest
     steps:
+      - timeout-minutes: 10
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:

--- a/README.md
+++ b/README.md
@@ -93,3 +93,5 @@ For more detailed documentation
 
 - [Actor Lifecycle](doc/ActorLifecycle.md)
 - [Processor](doc/Processor.md)
+- [Messaging](doc/Messaging.md)
+- [Serialization](doc/Serialization.md)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.plugins.ide.idea.model.IdeaLanguageLevel
 import pt.pak3nuh.hollywood.gradle.Dependencies
 
 plugins {
-    kotlin("jvm") version "1.3.70"
+    kotlin("jvm") version "1.3.72"
     idea
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.3.70"
+    kotlin("jvm") version "1.3.72"
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/pt/pak3nuh/hollywood/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/pt/pak3nuh/hollywood/gradle/Versions.kt
@@ -2,29 +2,32 @@ package pt.pak3nuh.hollywood.gradle
 
 private object Versions {
     // plugin versions must be changed inline
-    val kotlin = "1.3.70"
-    val junit = "5.6.0"
-    val assertK = "0.20"
-    val coroutines = "1.3.4"
-    val mockk = "1.9.3"
-    val kryo = "5.0.0-RC5"
+    const val kotlin = "1.3.72"
+    const val coroutines = "1.3.5"
+    const val metadata = "0.1.0"
+    const val junit = "5.6.0"
+    const val kotlinPoet = "1.5.0"
+    const val assertK = "0.20"
+    const val mockk = "1.9.3"
+    const val kryo = "5.0.0-RC5"
 }
 
 object Dependencies {
-    val kotlinPoet = "com.squareup:kotlinpoet:1.5.0"
+    val kotlinPoet = artifact("com.squareup", "kotlinpoet", Versions.kotlinPoet)
     val kotlinCoroutines = kotlinx("kotlinx-coroutines-core", Versions.coroutines)
-    val kotlinMetadata = kotlinx("kotlinx-metadata-jvm", "0.1.0")
+    val kotlinMetadata = kotlinx("kotlinx-metadata-jvm", Versions.metadata)
 
     // todo as of kotiln 1.3.70 this may not be needed
     val kotlinReflect = kotlin("reflect", Versions.kotlin)
     val kotlinStdLib = kotlin("stdlib-jdk8", Versions.kotlin)
     val junitApi = junitJupiter("api", Versions.junit)
     val junitEngine = junitJupiter("engine", Versions.junit)
-    val assertK = "com.willowtreeapps.assertk:assertk-jvm:${Versions.assertK}"
-    val mockk = "io.mockk:mockk:${Versions.mockk}"
-    val kryo = "com.esotericsoftware:kryo:${Versions.kryo}"
+    val assertK = artifact("com.willowtreeapps.assertk", "assertk-jvm", Versions.assertK)
+    val mockk = artifact("io.mockk", "mockk", Versions.mockk)
+    val kryo = artifact("com.esotericsoftware", "kryo", Versions.kryo)
 }
 
-private fun kotlinx(name: String, version: String) = "org.jetbrains.kotlinx:$name:$version"
-private fun kotlin(name: String, version: String) = "org.jetbrains.kotlin:kotlin-$name:$version"
-private fun junitJupiter(name: String, version: String) = "org.junit.jupiter:junit-jupiter-$name:$version"
+private fun artifact(group: String, name: String, version: String) = "$group:$name:$version"
+private fun kotlinx(name: String, version: String) = artifact("org.jetbrains.kotlinx", name, version)
+private fun kotlin(name: String, version: String) = artifact("org.jetbrains.kotlin", "kotlin-$name", version)
+private fun junitJupiter(name: String, version: String) = artifact("org.junit.jupiter", "junit-jupiter-$name", version)

--- a/buildSrc/src/main/kotlin/pt/pak3nuh/hollywood/gradle/Versions.kt
+++ b/buildSrc/src/main/kotlin/pt/pak3nuh/hollywood/gradle/Versions.kt
@@ -13,6 +13,7 @@ private object Versions {
 object Dependencies {
     val kotlinPoet = "com.squareup:kotlinpoet:1.5.0"
     val kotlinCoroutines = kotlinx("kotlinx-coroutines-core", Versions.coroutines)
+    val kotlinMetadata = kotlinx("kotlinx-metadata-jvm", "0.1.0")
 
     // todo as of kotiln 1.3.70 this may not be needed
     val kotlinReflect = kotlin("reflect", Versions.kotlin)

--- a/doc/Processor.md
+++ b/doc/Processor.md
@@ -75,6 +75,9 @@ this [bellow](#Constraints)
 but it has not reached the stable state yet. For that reason and because the data it may be unreadable, 
 the features provided by the annotation must be considered **optional** and the Mirror API the main source of truth.
 
+Metadata mode can explicitly be disabled by setting a system property:
+`hollywood.processor.disable-kotlin-metadata=true`
+
 ## Constraints
 
 These constraints reflect the current status of the project and may change in the future.

--- a/doc/Processor.md
+++ b/doc/Processor.md
@@ -55,6 +55,26 @@ class GreeterProxy(
 
 There are some constraints for this, please see [bellow](#Constraints)
 
+## Two generator options
+
+Because this is a `kotlin` source generator on a `java` annotation processor environment there are two sources of information
+available to build the classes.
+
+1. `java` Mirror API
+2. `kotlin` Metadata annotation
+
+Most of the information required to generate the source files is available in the Mirror API, but there are some caveats.
+There isn't enough information to infer nullability of all arguments in the function parameters, and this is where the
+Metadata that the `kotlin` compiler emits comes in handy.
+
+When this annotation is present and readable, the processor can inspect a much closer representation of the actor
+interface. When it is not available the generator falls back to plain Mirror API and some features are lost. More on
+this [bellow](#Constraints)
+
+**NOTE**: The library used to read the metadata is on the official [Kotlin repo](https://github.com/JetBrains/kotlin/tree/master/libraries/kotlinx-metadata/jvm)
+but it has not reached the stable state yet. For that reason and because the data it may be unreadable, 
+the features provided by the annotation must be considered **optional** and the Mirror API the main source of truth.
+
 ## Constraints
 
 These constraints reflect the current status of the project and may change in the future.
@@ -62,7 +82,7 @@ These constraints reflect the current status of the project and may change in th
 #### Suspend everywhere
 
 All methods of an actor must be **suspendable**. This is because an actor will work with
-mailboxes, serialization, possibly network and those are inheritably async in nature.
+mailboxes, serialization, possibly network, and those are inheritably async in nature.
 
 This should be expected because actor communication is message based and the actor model
 gives the guarantee that only one message is processed at any time.
@@ -76,7 +96,16 @@ hierarchies, different proxies need to be issued and this increases project
 complexity for little (and convoluted) gain.
 Although is possible to create actors manually that don't use interfaces but a class hierarchy.
 
-#### Not all kotlin types are supported
+#### Nullability support is not ensured
+If the `kotlin` compiler metadata isn't available the generator will fallback to the Mirror API. In this mode
+the nullability of the parameters and return type can't be obtained and all the actor signatures must be
+non null.
+
+While this may be an inconvenience, nullability can be easily avoided with overloads and wrapping types like Optional.
+
+#### Not all `kotlin` types are supported
+**Only applies to Mirror API mode**
+
 Because this is a `java` annotation processor, the `kotlin` compiler will issue `elements` native
 to the `JDK` ecosystem. This means that the opposite process must exist, transforming `java` 
 elements into `kotlin` types.
@@ -85,7 +114,7 @@ Since there is no such mechanism provided by the `kotlin` ecosystem, it was chos
 only a subset of those translations. This subset tries to provide just the basic blocks needed
 without having to create a new type for the interaction.
 
-The subset is in this [file](../processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/types/TypeConverter.kt)
+The subset is in this [file](../processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/TypeConverter.kt)
 and they are roughly:
 - Primitives
 - Arrays
@@ -123,7 +152,7 @@ will use functionalities present in this class. It is safer to extend the class 
 maintaining some brittle naming contract.
 
 Some of this restriction apply in different phases. Some will break the annotation processor,
-others will break on the kotlin compilation phase.
+others will break on the `kotlin` compilation phase.
 
 ## Proxy structure
 

--- a/integration-test/src/main/kotlin/pt/pakenuh/hollywood/sandbox/actor/GeneratorTest.kt
+++ b/integration-test/src/main/kotlin/pt/pakenuh/hollywood/sandbox/actor/GeneratorTest.kt
@@ -49,6 +49,12 @@ interface TypeMappingActor {
     // different signature between nullable array and primitive array
     suspend fun arrayNullableOverload(primitiveArray: Array<Int?>)
     suspend fun arrayNullableOverload(primitiveArray: IntArray)
+
+    suspend fun typeAliasWithGeneric(p1: Gen<String?>)
+
+    suspend fun nothingFunction(): Nothing
 }
+
+typealias Gen<T> = Generic<T>
 
 class Generic<T>

--- a/integration-test/src/main/kotlin/pt/pakenuh/hollywood/sandbox/actor/GeneratorTest.kt
+++ b/integration-test/src/main/kotlin/pt/pakenuh/hollywood/sandbox/actor/GeneratorTest.kt
@@ -1,7 +1,7 @@
 package pt.pakenuh.hollywood.sandbox.actor
 
 import pt.pak3nuh.hollywood.processor.Actor
-
+// todo run this test with metadata enabled and disabled. check detekt project to see how a gradle build can be run inside a test case
 /**
  * Generated actor must map java types to kotlin types in both parameters and return types
  * If the generated code compiles, the test passes
@@ -53,6 +53,9 @@ interface TypeMappingActor {
     suspend fun typeAliasWithGeneric(p1: Gen<String?>)
 
     suspend fun nothingFunction(): Nothing
+
+//    suspend fun actorParametersNotAllowed(p1: TypeMappingActor)
+//    suspend fun actorParametersNotAllowed(): TypeMappingActor
 }
 
 typealias Gen<T> = Generic<T>

--- a/integration-test/src/main/kotlin/pt/pakenuh/hollywood/sandbox/actor/GeneratorTest.kt
+++ b/integration-test/src/main/kotlin/pt/pakenuh/hollywood/sandbox/actor/GeneratorTest.kt
@@ -39,12 +39,16 @@ interface TypeMappingActor {
         return string.toCharArray()
     }
 
-    // todo nullables don't work
-    //suspend fun nullableType(p1: Int?): List<String?>
+    suspend fun nullableType(p1: Int?): List<String>?
+
+    suspend fun nullableGeneric(p1: Generic<String?>): List<String?>
+
+    // not supported by design
+    //suspend fun <T> typeParameter(p1: T)
 
     // different signature between nullable array and primitive array
-    //suspend fun arrayNullableOverload(primitiveArray: Array<Int?>)
-    //suspend fun arrayNullableOverload(primitiveArray: IntArray)
+    suspend fun arrayNullableOverload(primitiveArray: Array<Int?>)
+    suspend fun arrayNullableOverload(primitiveArray: IntArray)
 }
 
 class Generic<T>

--- a/integration-test/src/main/kotlin/pt/pakenuh/hollywood/sandbox/actor/GeneratorTest.kt
+++ b/integration-test/src/main/kotlin/pt/pakenuh/hollywood/sandbox/actor/GeneratorTest.kt
@@ -1,7 +1,7 @@
 package pt.pakenuh.hollywood.sandbox.actor
 
 import pt.pak3nuh.hollywood.processor.Actor
-// todo run this test with metadata enabled and disabled. check detekt project to see how a gradle build can be run inside a test case
+// todo make 2 test suites, one for metadata enabled and another for disabled. check detekt for gradle runs on junit
 /**
  * Generated actor must map java types to kotlin types in both parameters and return types
  * If the generated code compiles, the test passes

--- a/processor/processor-core/build.gradle.kts
+++ b/processor/processor-core/build.gradle.kts
@@ -3,6 +3,6 @@ import pt.pak3nuh.hollywood.gradle.Dependencies
 dependencies {
     implementation(project(":api"))
     implementation(Dependencies.kotlinPoet)
-    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0")
+    implementation(Dependencies.kotlinMetadata)
     testImplementation(Dependencies.mockk)
 }

--- a/processor/processor-core/build.gradle.kts
+++ b/processor/processor-core/build.gradle.kts
@@ -3,5 +3,6 @@ import pt.pak3nuh.hollywood.gradle.Dependencies
 dependencies {
     implementation(project(":api"))
     implementation(Dependencies.kotlinPoet)
+    implementation("org.jetbrains.kotlinx:kotlinx-metadata-jvm:0.1.0")
     testImplementation(Dependencies.mockk)
 }

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorFactoryGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorFactoryGenerator.kt
@@ -12,7 +12,7 @@ import com.squareup.kotlinpoet.asTypeName
 import pt.pak3nuh.hollywood.actor.ActorFactory
 import pt.pak3nuh.hollywood.actor.proxy.ProxyConfiguration
 import pt.pak3nuh.hollywood.processor.generator.context.GenerationContext
-import pt.pak3nuh.hollywood.processor.generator.context.buildGenerationAnnotation
+import pt.pak3nuh.hollywood.processor.generator.context.generationAnnotation
 import pt.pak3nuh.hollywood.processor.visitor.TypeElementVisitor
 import javax.lang.model.element.TypeElement
 import kotlin.reflect.KClass
@@ -42,7 +42,7 @@ class ActorFactoryGenerator : FileGenerator, TypeElementVisitor() {
                 .build()
 
         val classBuilder = TypeSpec.interfaceBuilder(factoryName)
-                .addAnnotation(context.buildGenerationAnnotation())
+                .addAnnotation(context.generationAnnotation())
                 .addProperty(actorKClassProp)
                 .addProperty(proxyKClassProp)
                 .addFunction(proxyCreator)

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorFactoryGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorFactoryGenerator.kt
@@ -13,7 +13,7 @@ import pt.pak3nuh.hollywood.actor.ActorFactory
 import pt.pak3nuh.hollywood.actor.proxy.ProxyConfiguration
 import pt.pak3nuh.hollywood.processor.generator.context.GenerationContext
 import pt.pak3nuh.hollywood.processor.generator.context.generationAnnotation
-import pt.pak3nuh.hollywood.processor.visitor.TypeElementVisitor
+import pt.pak3nuh.hollywood.processor.generator.mirror.visitor.TypeElementVisitor
 import javax.lang.model.element.TypeElement
 import kotlin.reflect.KClass
 

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGenerator.kt
@@ -1,84 +1,31 @@
 package pt.pak3nuh.hollywood.processor.generator
 
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.ParameterSpec
-import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.squareup.kotlinpoet.TypeSpec
-import com.squareup.kotlinpoet.asTypeName
-import pt.pak3nuh.hollywood.actor.proxy.ProxyConfiguration
-import pt.pak3nuh.hollywood.processor.Actor
 import pt.pak3nuh.hollywood.processor.generator.context.GenerationContext
-import pt.pak3nuh.hollywood.processor.generator.context.generationAnnotation
-import pt.pak3nuh.hollywood.processor.generator.types.KotlinMetadata
-import pt.pak3nuh.hollywood.processor.generator.types.TypeUtil
-import pt.pak3nuh.hollywood.processor.visitor.TypeElementVisitor
+import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaClass
 import javax.lang.model.element.ElementKind
 import javax.lang.model.element.TypeElement
-import javax.lang.model.type.TypeMirror
 
 class ActorProxyGenerator(
-        private val methodGenerator: MethodVisitor,
-        private val metadataExtractor: (TypeElement) -> KotlinMetadata
-) : FileGenerator, TypeElementVisitor() {
+        private val metadataExtractor: (TypeElement) -> MetaClass?,
+        private val javacGenerator: FileGenerator,
+        private val kotlinMetadataGenerator: FileGenerator
+) : FileGenerator {
 
     override fun generate(element: TypeElement, context: GenerationContext): SourceFile {
         require(element.kind == ElementKind.INTERFACE) {
             "Actor annotation can only be used on interfaces"
         }
-        context[KotlinMetadata] = metadataExtractor(element)
-        val sourceFile = visitType(element, context).toSourceFile()
-        context.remove(KotlinMetadata)
+
+        // todo fallback to java generator if error??
+        val kotlinMetadata = metadataExtractor(element)
+        val sourceFile = if (kotlinMetadata == null) {
+            javacGenerator.generate(element, context)
+        } else {
+            context[MetaClass] = kotlinMetadata
+            kotlinMetadataGenerator.generate(element, context)
+        }
+
+        context.remove(MetaClass)
         return sourceFile
     }
-
-    override fun visitType(typeElement: TypeElement, context: GenerationContext): TypeResult {
-        val actorInterface = typeElement.asType().asTypeName()
-
-        val newClassName = ClassName.bestGuess("${actorInterface}Proxy")
-        val parameterizedProxy = getProxyBaseClass(typeElement, context.typeUtil).parameterizedBy(actorInterface)
-
-        val delegateParam = ParameterSpec.builder("delegate", actorInterface).build()
-        val configParam = ParameterSpec.builder("config", ProxyConfiguration::class.asTypeName()).build()
-
-        val ctr = FunSpec
-                .constructorBuilder()
-                .addParameter(delegateParam)
-                .addParameter(configParam)
-                .build()
-
-        val classBuilder = TypeSpec.classBuilder(newClassName)
-                .addAnnotation(context.generationAnnotation())
-                .primaryConstructor(ctr)
-                .superclass(parameterizedProxy)
-                .addSuperclassConstructorParameter(delegateParam.name)
-                .addSuperclassConstructorParameter(configParam.name)
-                .addSuperinterface(actorInterface)
-
-        typeElement.enclosedElements.asSequence()
-                .map { it.accept(methodGenerator, context) }
-                .filterIsInstance<MethodResult>()
-                .forEach {
-                    classBuilder.addFunction(it.funSpec)
-                }
-
-        return TypeResult(newClassName, classBuilder.build())
-    }
-
-    private fun getProxyBaseClass(e: TypeElement, typeUtil: TypeUtil): ClassName {
-        val annotationValue = e.annotationMirrors.asSequence()
-                .filter { it.annotationType.toString() == Actor::class.qualifiedName }
-                .flatMap { annotation ->
-                    typeUtil.getElementValuesWithDefaults(annotation).filterKeys { key ->
-                        key.simpleName.contentEquals(Actor::value.name)
-                    }.values.asSequence()
-                }.first()
-
-
-        val value = annotationValue.value as TypeMirror
-        require(typeUtil.isValidProxy(value)) { "Type $value is not a valid proxy" }
-
-        return ClassName.bestGuess(value.toString())
-    }
 }
-

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGenerator.kt
@@ -16,12 +16,13 @@ class ActorProxyGenerator(
             "Actor annotation can only be used on interfaces"
         }
 
-        // todo fallback to java generator if error??
         val kotlinMetadata = metadataExtractor(element)
         val sourceFile = if (kotlinMetadata == null) {
+            context.logger.logInfo("Kotlin metadata not available for type $element")
             javacGenerator.generate(element, context)
         } else {
             context[MetaClass] = kotlinMetadata
+            context.logger.logInfo("Using Kotlin metadata for type $element")
             kotlinMetadataGenerator.generate(element, context)
         }
 

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGenerator.kt
@@ -16,7 +16,7 @@ class ActorProxyGenerator(
             "Actor annotation can only be used on interfaces"
         }
 
-        val kotlinMetadata: MetaClass? = metadataExtractor(element)
+        val kotlinMetadata: MetaClass? = if (context.useMetadata) metadataExtractor(element) else null
         val sourceFile = if (kotlinMetadata == null) {
             context.logger.logInfo("Kotlin metadata not available for type $element")
             javacGenerator.generate(element, context)

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGenerator.kt
@@ -16,7 +16,7 @@ class ActorProxyGenerator(
             "Actor annotation can only be used on interfaces"
         }
 
-        val kotlinMetadata = metadataExtractor(element)
+        val kotlinMetadata: MetaClass? = metadataExtractor(element)
         val sourceFile = if (kotlinMetadata == null) {
             context.logger.logInfo("Kotlin metadata not available for type $element")
             javacGenerator.generate(element, context)

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/GeneratorFacade.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/GeneratorFacade.kt
@@ -48,7 +48,7 @@ class GeneratorFacade : AbstractProcessor() {
         val typeChecker = TypeChecker(typeUtil)
         val javaGenerator = JavaProxyGenerator(MethodGenerator(typeChecker))
         val kotlinMethodGenerator = KotlinProxyGenerator(typeChecker)
-        val kotlinMetadataExtractor = KotlinMetadataExtractor(typeUtil.metadataType)
+        val kotlinMetadataExtractor = KotlinMetadataExtractor(typeUtil.metadataType, logger)
         val generators = sequenceOf<FileGenerator>(
                 ActorProxyGenerator(kotlinMetadataExtractor::extract, javaGenerator, kotlinMethodGenerator),
                 ActorFactoryGenerator()

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/GeneratorFacade.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/GeneratorFacade.kt
@@ -2,6 +2,7 @@ package pt.pak3nuh.hollywood.processor.generator
 
 import pt.pak3nuh.hollywood.processor.Actor
 import pt.pak3nuh.hollywood.processor.generator.context.GenerationContextImpl
+import pt.pak3nuh.hollywood.processor.generator.types.KotlinMetadataExtractor
 import pt.pak3nuh.hollywood.processor.generator.types.TypeConverter
 import pt.pak3nuh.hollywood.processor.generator.types.TypeUtilImpl
 import pt.pak3nuh.hollywood.processor.generator.util.Logger
@@ -41,8 +42,9 @@ class GeneratorFacade : AbstractProcessor() {
         val typeUtil = TypeUtilImpl(logger, processingEnv.typeUtils, processingEnv.elementUtils, TypeConverter())
         val ctx = GenerationContextImpl(logger, typeUtil)
         val methodGenerator = MethodGenerator()
+        val kotlinMetadataExtractor = KotlinMetadataExtractor(typeUtil.metadataType)
         val generators = sequenceOf<FileGenerator>(
-                ActorProxyGenerator(methodGenerator),
+                ActorProxyGenerator(methodGenerator, kotlinMetadataExtractor::extract),
                 ActorFactoryGenerator()
         )
         annotatedElements.asSequence()

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/GeneratorFacade.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/GeneratorFacade.kt
@@ -44,7 +44,7 @@ class GeneratorFacade : AbstractProcessor() {
 
     private fun generateFiles(annotatedElements: Set<Element>, destinationFolder: String) {
         val typeUtil = TypeUtilImpl(logger, processingEnv.typeUtils, processingEnv.elementUtils, TypeConverter())
-        val ctx = GenerationContextImpl(logger, typeUtil)
+        val ctx = GenerationContextImpl(logger, typeUtil, isMetadataEnabled())
         val typeChecker = TypeChecker(typeUtil)
         val javaGenerator = JavaProxyGenerator(MethodGenerator(typeChecker))
         val kotlinMethodGenerator = KotlinProxyGenerator(typeChecker)
@@ -65,6 +65,11 @@ class GeneratorFacade : AbstractProcessor() {
                     logger.logInfo("Writing source file $it")
                     it.writeTo(Paths.get(destinationFolder))
                 }
+    }
+
+    private fun isMetadataEnabled(): Boolean {
+        val property: String? = System.getProperty("hollywood.processor.disable-kotlin-metadata")
+        return property?.toBoolean()?.not() ?: true
     }
 
     override fun init(processingEnv: ProcessingEnvironment) {

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/GenerationContext.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/GenerationContext.kt
@@ -6,6 +6,7 @@ import pt.pak3nuh.hollywood.processor.generator.util.Logger
 interface GenerationContext {
     val logger: Logger
     val typeUtil: TypeUtil
+    val useMetadata: Boolean
 
     operator fun <T : Any> set(property: Property<T>, data: T): GenerationContext
     operator fun <T> get(property: Property<T>): T?
@@ -13,7 +14,11 @@ interface GenerationContext {
 }
 
 @Suppress("UNCHECKED_CAST")
-class GenerationContextImpl(override val logger: Logger, override val typeUtil: TypeUtil): GenerationContext {
+class GenerationContextImpl(
+        override val logger: Logger,
+        override val typeUtil: TypeUtil,
+        override val useMetadata: Boolean
+): GenerationContext {
 
     private val map = mutableMapOf<Property<*>, Any>()
 

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/GenerationContext.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/GenerationContext.kt
@@ -9,8 +9,10 @@ interface GenerationContext {
 
     operator fun <T : Any> set(property: Property<T>, data: T): GenerationContext
     operator fun <T> get(property: Property<T>): T?
+    fun <T> remove(property: Property<T>): T?
 }
 
+@Suppress("UNCHECKED_CAST")
 class GenerationContextImpl(override val logger: Logger, override val typeUtil: TypeUtil): GenerationContext {
 
     private val map = mutableMapOf<Property<*>, Any>()
@@ -21,8 +23,10 @@ class GenerationContextImpl(override val logger: Logger, override val typeUtil: 
     }
 
     override operator fun <T> get(property: Property<T>): T? {
-        @Suppress("UNCHECKED_CAST")
         return map[property] as T?
     }
 
+    override fun <T> remove(property: Property<T>): T? {
+        return map.remove(property) as T?
+    }
 }

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/GenerationContext.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/GenerationContext.kt
@@ -1,6 +1,6 @@
 package pt.pak3nuh.hollywood.processor.generator.context
 
-import pt.pak3nuh.hollywood.processor.generator.types.TypeUtil
+import pt.pak3nuh.hollywood.processor.generator.mirror.TypeUtil
 import pt.pak3nuh.hollywood.processor.generator.util.Logger
 
 interface GenerationContext {

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/Properties.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/Properties.kt
@@ -2,6 +2,7 @@ package pt.pak3nuh.hollywood.processor.generator.context
 
 import com.squareup.kotlinpoet.AnnotationSpec
 import pt.pak3nuh.hollywood.processor.Generated
+import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaClass
 import java.time.Instant
 
 fun GenerationContext.generationAnnotation(): AnnotationSpec {
@@ -17,3 +18,5 @@ fun GenerationContext.generationAnnotation(): AnnotationSpec {
     set(GenerationAnnotation, GenerationAnnotation(generatedAnnotation))
     return generatedAnnotation
 }
+
+fun GenerationContext.getKotlinMetadata(): MetaClass? = this[MetaClass]

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/Properties.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/Properties.kt
@@ -4,16 +4,16 @@ import com.squareup.kotlinpoet.AnnotationSpec
 import pt.pak3nuh.hollywood.processor.Generated
 import java.time.Instant
 
-fun GenerationContext.buildGenerationAnnotation(): AnnotationSpec {
+fun GenerationContext.generationAnnotation(): AnnotationSpec {
     val existing = get(GenerationAnnotation)
     if (existing != null) {
-        return existing
+        return existing.annotationSpec
     }
 
     val generatedAnnotation = AnnotationSpec.builder(Generated::class)
             .addMember("%S", Instant.now())
             .build()
 
-    set(GenerationAnnotation, generatedAnnotation)
+    set(GenerationAnnotation, GenerationAnnotation(generatedAnnotation))
     return generatedAnnotation
 }

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/Property.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/context/Property.kt
@@ -2,6 +2,8 @@ package pt.pak3nuh.hollywood.processor.generator.context
 
 import com.squareup.kotlinpoet.AnnotationSpec
 
-sealed class Property<T>
+interface Property<T>
 
-object GenerationAnnotation: Property<AnnotationSpec>()
+class GenerationAnnotation(val annotationSpec: AnnotationSpec) {
+    companion object Key: Property<GenerationAnnotation>
+}

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/KotlinMetadataExtractor.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/KotlinMetadataExtractor.kt
@@ -1,31 +1,26 @@
 @file:Suppress("UNCHECKED_CAST")
 
-package pt.pak3nuh.hollywood.processor.generator.types
+package pt.pak3nuh.hollywood.processor.generator.metadata
 
-import kotlinx.metadata.KmClass
 import kotlinx.metadata.jvm.KotlinClassHeader
 import kotlinx.metadata.jvm.KotlinClassMetadata
-import pt.pak3nuh.hollywood.processor.generator.context.Property
+import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaClass
 import javax.lang.model.element.AnnotationMirror
 import javax.lang.model.element.AnnotationValue
 import javax.lang.model.element.TypeElement
-
-interface KotlinMetadata {
-    companion object Key : Property<KotlinMetadata>
-}
 
 class KotlinMetadataExtractor(
         private val metadataType: TypeElement
 ) {
 
-    fun extract(typeElement: TypeElement): KotlinMetadata {
+    fun extract(typeElement: TypeElement): MetaClass? {
         val metadataAnnotation = typeElement.annotationMirrors.first { it.annotationType.asElement() == metadataType }
         val header = convertHeader(metadataAnnotation)
         val metadata = KotlinClassMetadata.read(header)
         return if (metadata == null) {
-            UnsupportedMetadata(typeElement)
+            null
         } else {
-            FullKotlinMetadata((metadata as KotlinClassMetadata.Class).toKmClass())
+            MetaClass((metadata as KotlinClassMetadata.Class).toKmClass())
         }
     }
 
@@ -102,7 +97,3 @@ class KotlinMetadataExtractor(
     }
 
 }
-
-class FullKotlinMetadata(val metadata: KmClass): KotlinMetadata
-
-class UnsupportedMetadata(val typeElement: TypeElement) : KotlinMetadata

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/KotlinProxyGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/KotlinProxyGenerator.kt
@@ -1,0 +1,66 @@
+package pt.pak3nuh.hollywood.processor.generator.metadata
+
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterSpec
+import pt.pak3nuh.hollywood.processor.generator.MethodResult
+import pt.pak3nuh.hollywood.processor.generator.context.GenerationContext
+import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaClass
+import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaFun
+import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaType
+import pt.pak3nuh.hollywood.processor.generator.metadata.type.WellKnownTypes
+import pt.pak3nuh.hollywood.processor.generator.mirror.ProxyClassGenerator
+import pt.pak3nuh.hollywood.processor.generator.util.Logger
+import pt.pak3nuh.hollywood.processor.generator.util.TypeChecker
+import javax.lang.model.element.TypeElement
+
+
+class KotlinProxyGenerator(
+        private val typeChecker: TypeChecker
+) : ProxyClassGenerator() {
+
+    override fun buildFunctions(typeElement: TypeElement, context: GenerationContext): List<MethodResult> {
+        val classMetadata = requireNotNull(context[MetaClass]) { "Kotlin class metadata is required" }
+        return buildFunctions(classMetadata, context.logger)
+    }
+
+    private fun buildFunctions(metadata: MetaClass, logger: Logger): List<MethodResult> {
+        logger.logDebug("Generating functions of class ${metadata.name}")
+        return metadata.functions.map { buildFunction(it, logger) }
+    }
+
+    private fun buildFunction(metadata: MetaFun, logger: Logger): MethodResult {
+        logger.logDebug("Generating function ${metadata.name}")
+        val returnType = typeChecker.checkIsSuspend(metadata)
+        typeChecker.checkNotActor(returnType)
+
+        val parameters = metadata.parameters
+                .onEach { typeChecker.checkNotActor(it.type) }
+                .map { ParameterSpec.builder(it.name ,it.type.asTypeName()).build() }
+                .toList()
+
+        val builder = FunSpec.builder(metadata.name)
+                .addModifiers(KModifier.OVERRIDE, KModifier.SUSPEND)
+                .returns(returnType.asTypeName())
+                .addParameters(parameters)
+                .addCode(buildDelegateCall(metadata.name, returnType, parameters))
+
+        return MethodResult(builder.build())
+    }
+
+    private fun buildDelegateCall(methodName: String, returnType: MetaType, parameterSpecs: List<ParameterSpec>): CodeBlock {
+        val parametersAsString = parameterSpecs.joinToString(", ") { it.name }
+        val hasReturnStatement = returnType != WellKnownTypes.unitType
+        val builder = if (hasReturnStatement) {
+            CodeBlock.builder().add("return ")
+        } else {
+            CodeBlock.builder()
+        }
+
+        return builder.beginControlFlow("execCall")
+                .indent().addStatement("delegate.%L(%L)", methodName, parametersAsString)
+                .unindent().endControlFlow()
+                .build()
+    }
+}

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/package-info.java
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package for kotlin [Metadata] based generators.
+ */
+package pt.pak3nuh.hollywood.processor.generator.metadata;

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaClassImpl.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaClassImpl.kt
@@ -1,0 +1,11 @@
+package pt.pak3nuh.hollywood.processor.generator.metadata.type
+
+import kotlinx.metadata.KmClass
+
+@Suppress("FunctionName")
+fun MetaClass(kmClass: KmClass): MetaClass = MetaClassImpl(kmClass)
+private class MetaClassImpl(val kmClass: KmClass) : MetaClass {
+    override val functions: List<MetaFun> = kmClass.functions.map { MetaFun(it) }
+    override val name: String
+        get() = kmClass.name
+}

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaFunImpl.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaFunImpl.kt
@@ -1,0 +1,20 @@
+package pt.pak3nuh.hollywood.processor.generator.metadata.type
+
+import kotlinx.metadata.Flag
+import kotlinx.metadata.KmFunction
+
+@Suppress("FunctionName")
+fun MetaFun(kmFunction: KmFunction): MetaFun = MetaFunImpl(kmFunction)
+
+private class MetaFunImpl(val kmFunction: KmFunction) : MetaFun {
+    override val parameters: List<MetaParameter> = kmFunction.valueParameters
+            .map { MetaParameter(it, kmFunction.typeParameters) }
+
+    override val isSuspend: Boolean
+        get() = Flag.Function.IS_SUSPEND(kmFunction.flags)
+
+    override val name: String
+        get() = kmFunction.name
+
+    override val returnType: MetaType = MetaType(kmFunction.returnType, kmFunction.typeParameters)
+}

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaInterfaces.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaInterfaces.kt
@@ -1,0 +1,40 @@
+package pt.pak3nuh.hollywood.processor.generator.metadata.type
+
+import com.squareup.kotlinpoet.TypeName
+import pt.pak3nuh.hollywood.processor.generator.context.Property
+import kotlin.reflect.KClass
+
+/**
+ * Interpretation of the [Metadata] emitted by the kotlin compiler. This metadata contain a lot more information
+ * than the mirror API provided by the java compiler, but it has not reached a stable point.
+ *
+ * For that reason **javac** should remain the main source of information.
+ */
+// todo documentation
+interface MetaClass {
+    val functions: List<MetaFun>
+    val name: String
+
+    companion object Key : Property<MetaClass>
+}
+
+interface MetaFun {
+    val parameters: List<MetaParameter>
+    val isSuspend: Boolean
+    val name: String
+    val returnType: MetaType
+}
+
+interface MetaParameter {
+    val name: String
+    val type: MetaType
+}
+
+interface MetaType {
+    val name: String
+    val isNullable: Boolean
+    // bound to Kotlin Poet to cut over engineering. can be improved if necessary
+    fun asTypeName(): TypeName
+    fun hasAnnotation(kClass: KClass<out Annotation>): Boolean
+}
+

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaInterfaces.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaInterfaces.kt
@@ -2,7 +2,6 @@ package pt.pak3nuh.hollywood.processor.generator.metadata.type
 
 import com.squareup.kotlinpoet.TypeName
 import pt.pak3nuh.hollywood.processor.generator.context.Property
-import kotlin.reflect.KClass
 
 /**
  * Interpretation of the [Metadata] emitted by the kotlin compiler. This metadata contain a lot more information
@@ -33,6 +32,5 @@ interface MetaType {
     val name: String
     // bound to Kotlin Poet to cut over engineering. can be abstracted if necessary
     fun asTypeName(): TypeName
-    fun hasAnnotation(kClass: KClass<out Annotation>): Boolean
 }
 

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaInterfaces.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaInterfaces.kt
@@ -10,7 +10,6 @@ import kotlin.reflect.KClass
  *
  * For that reason **javac** should remain the main source of information.
  */
-// todo documentation
 interface MetaClass {
     val functions: List<MetaFun>
     val name: String
@@ -32,8 +31,7 @@ interface MetaParameter {
 
 interface MetaType {
     val name: String
-    val isNullable: Boolean
-    // bound to Kotlin Poet to cut over engineering. can be improved if necessary
+    // bound to Kotlin Poet to cut over engineering. can be abstracted if necessary
     fun asTypeName(): TypeName
     fun hasAnnotation(kClass: KClass<out Annotation>): Boolean
 }

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaParameterImpl.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaParameterImpl.kt
@@ -1,0 +1,24 @@
+package pt.pak3nuh.hollywood.processor.generator.metadata.type
+
+import kotlinx.metadata.KmTypeParameter
+import kotlinx.metadata.KmValueParameter
+
+@Suppress("FunctionName")
+fun MetaParameter(
+        valueParameter: KmValueParameter,
+        typeParameters: List<KmTypeParameter>
+): MetaParameter = MetaParameterImpl(valueParameter, typeParameters)
+
+private class MetaParameterImpl(
+        val parameter: KmValueParameter,
+        val typeParameters: List<KmTypeParameter>
+) : MetaParameter {
+    override val name: String
+        get() = parameter.name
+    override val type: MetaType = findType()
+
+    private fun findType(): MetaType {
+        val kmType = parameter.type ?: parameter.varargElementType ?: error("Parameter $parameter must have a type!")
+        return MetaType(kmType, typeParameters)
+    }
+}

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaTypeImpl.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaTypeImpl.kt
@@ -101,4 +101,8 @@ class TypeVisitor(
     override fun visitArgument(flags: Flags, variance: KmVariance): KmTypeVisitor? {
         return TypeVisitor(flags, variance, this)
     }
+
+    override fun visitTypeParameter(id: Int) {
+        error("Type parameters not supported")
+    }
 }

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaTypeImpl.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaTypeImpl.kt
@@ -37,9 +37,6 @@ class MetaTypeImpl(
         }
     }
 
-    override val isNullable: Boolean
-        get() = Flag.Type.IS_NULLABLE(kmType.flags)
-
     override fun asTypeName(): TypeName {
         return TypeVisitor(kmType.flags, KmVariance.INVARIANT, null).also(kmType::accept).typeName
     }

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaTypeImpl.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaTypeImpl.kt
@@ -1,0 +1,104 @@
+package pt.pak3nuh.hollywood.processor.generator.metadata.type
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.ParameterizedTypeName
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.STAR
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.WildcardTypeName
+import kotlinx.metadata.Flag
+import kotlinx.metadata.Flags
+import kotlinx.metadata.KmClassifier
+import kotlinx.metadata.KmType
+import kotlinx.metadata.KmTypeParameter
+import kotlinx.metadata.KmTypeVisitor
+import kotlinx.metadata.KmVariance
+import kotlinx.metadata.jvm.annotations
+import kotlin.reflect.KClass
+import kotlinx.metadata.ClassName as KClassName
+
+@Suppress("FunctionName")
+fun MetaType(
+        kmType: KmType,
+        typeParameters: List<KmTypeParameter>
+): MetaType = MetaTypeImpl(kmType, typeParameters)
+
+class MetaTypeImpl(
+        private val kmType: KmType,
+        private val typeParameters: List<KmTypeParameter>
+) : MetaType {
+    override val name: String = getTypeName()
+
+    private fun getTypeName(): String {
+        return when (val classifier = kmType.classifier) {
+            is KmClassifier.Class -> classifier.name
+            is KmClassifier.TypeAlias -> classifier.name
+            is KmClassifier.TypeParameter -> typeParameters.first { it.id == classifier.id }.name
+        }
+    }
+
+    override val isNullable: Boolean
+        get() = Flag.Type.IS_NULLABLE(kmType.flags)
+
+    override fun asTypeName(): TypeName {
+        return TypeVisitor(kmType.flags, KmVariance.INVARIANT, null).also(kmType::accept).typeName
+    }
+
+    override fun hasAnnotation(kClass: KClass<out Annotation>): Boolean {
+        val qualifiedName = requireNotNull(kClass.qualifiedName) { "Qualified name not found for $kClass" }
+        return kmType.annotations.any {
+            it.className == qualifiedName
+        }
+    }
+}
+
+class TypeVisitor(
+        private val flags: Flags,
+        private val variance: KmVariance,
+        private val parent: TypeVisitor?
+) : KmTypeVisitor() {
+
+    lateinit var typeName: TypeName
+        private set
+
+    override fun visitClass(kName: KClassName) {
+        // / -> .
+        // . -> annonymous classes, nor supported
+        val name = kName.replace('/', '.')
+        typeName = ClassName.bestGuess(name)
+    }
+
+    override fun visitStarProjection() {
+        parameterize(STAR)
+    }
+
+    private fun onChildEnd(child: TypeName) {
+        parameterize(child)
+    }
+
+    private fun parameterize(child: TypeName) {
+        typeName = when (val t = typeName) {
+            is ClassName -> t.parameterizedBy(child)
+            is ParameterizedTypeName -> t.plusParameter(child)
+            else -> error("Unsupported")
+        }
+    }
+
+    override fun visitEnd() {
+        var baseType = typeName
+        if (Flag.Type.IS_NULLABLE(flags)) {
+            baseType = baseType.copy(nullable = true)
+        }
+        baseType = when (variance) {
+            KmVariance.INVARIANT -> baseType
+            KmVariance.IN -> WildcardTypeName.consumerOf(baseType)
+            KmVariance.OUT -> WildcardTypeName.producerOf(baseType)
+        }
+        typeName = baseType
+        parent?.onChildEnd(baseType)
+    }
+
+    override fun visitArgument(flags: Flags, variance: KmVariance): KmTypeVisitor? {
+        return TypeVisitor(flags, variance, this)
+    }
+}

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaTypeImpl.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/MetaTypeImpl.kt
@@ -13,8 +13,6 @@ import kotlinx.metadata.KmType
 import kotlinx.metadata.KmTypeParameter
 import kotlinx.metadata.KmTypeVisitor
 import kotlinx.metadata.KmVariance
-import kotlinx.metadata.jvm.annotations
-import kotlin.reflect.KClass
 import kotlinx.metadata.ClassName as KClassName
 
 @Suppress("FunctionName")
@@ -31,8 +29,8 @@ class MetaTypeImpl(
 
     private fun getTypeName(): String {
         return when (val classifier = kmType.classifier) {
-            is KmClassifier.Class -> classifier.name
-            is KmClassifier.TypeAlias -> classifier.name
+            is KmClassifier.Class -> classifier.name.replace('/','.')
+            is KmClassifier.TypeAlias -> classifier.name.replace('/','.')
             is KmClassifier.TypeParameter -> typeParameters.first { it.id == classifier.id }.name
         }
     }
@@ -41,12 +39,6 @@ class MetaTypeImpl(
         return TypeVisitor(kmType.flags, KmVariance.INVARIANT, null).also(kmType::accept).typeName
     }
 
-    override fun hasAnnotation(kClass: KClass<out Annotation>): Boolean {
-        val qualifiedName = requireNotNull(kClass.qualifiedName) { "Qualified name not found for $kClass" }
-        return kmType.annotations.any {
-            it.className == qualifiedName
-        }
-    }
 }
 
 class TypeVisitor(

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/WellKnownTypes.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/WellKnownTypes.kt
@@ -24,8 +24,6 @@ private class WKType(kClass: KClass<*>, private val typeName: TypeName) : MetaTy
         return name.hashCode()
     }
 
-    override val isNullable = false
-
     override fun asTypeName(): TypeName = typeName
 
     override fun hasAnnotation(kClass: KClass<out Annotation>) = false

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/WellKnownTypes.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/WellKnownTypes.kt
@@ -26,5 +26,4 @@ private class WKType(kClass: KClass<*>, private val typeName: TypeName) : MetaTy
 
     override fun asTypeName(): TypeName = typeName
 
-    override fun hasAnnotation(kClass: KClass<out Annotation>) = false
 }

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/WellKnownTypes.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/metadata/type/WellKnownTypes.kt
@@ -1,0 +1,32 @@
+package pt.pak3nuh.hollywood.processor.generator.metadata.type
+
+import com.squareup.kotlinpoet.TypeName
+import com.squareup.kotlinpoet.UNIT
+import kotlin.reflect.KClass
+
+object WellKnownTypes {
+    val unitType: MetaType = WKType(Unit::class, UNIT)
+}
+
+private class WKType(kClass: KClass<*>, private val typeName: TypeName) : MetaType {
+
+    override val name: String = kClass.qualifiedName!!
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null || other !is MetaType) {
+            return false
+        }
+        // ignore nullability for these types
+        return other.name == name
+    }
+
+    override fun hashCode(): Int {
+        return name.hashCode()
+    }
+
+    override val isNullable = false
+
+    override fun asTypeName(): TypeName = typeName
+
+    override fun hasAnnotation(kClass: KClass<out Annotation>) = false
+}

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/JavaProxyGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/JavaProxyGenerator.kt
@@ -1,0 +1,18 @@
+package pt.pak3nuh.hollywood.processor.generator.mirror
+
+import pt.pak3nuh.hollywood.processor.generator.MethodResult
+import pt.pak3nuh.hollywood.processor.generator.context.GenerationContext
+import javax.lang.model.element.TypeElement
+
+class JavaProxyGenerator(
+        private val methodGenerator: MethodVisitor
+) : ProxyClassGenerator() {
+// todo documentation, limitations, only not nullable, etc
+    override fun buildFunctions(typeElement: TypeElement, context: GenerationContext): List<MethodResult> {
+        return typeElement.enclosedElements.asSequence()
+                .map { it.accept(methodGenerator, context) }
+                .filterIsInstance<MethodResult>()
+                .toList()
+    }
+
+}

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/JavaProxyGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/JavaProxyGenerator.kt
@@ -7,7 +7,7 @@ import javax.lang.model.element.TypeElement
 class JavaProxyGenerator(
         private val methodGenerator: MethodVisitor
 ) : ProxyClassGenerator() {
-// todo documentation, limitations, only not nullable, etc
+
     override fun buildFunctions(typeElement: TypeElement, context: GenerationContext): List<MethodResult> {
         return typeElement.enclosedElements.asSequence()
                 .map { it.accept(methodGenerator, context) }

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/ProxyClassGenerator.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/ProxyClassGenerator.kt
@@ -1,0 +1,79 @@
+package pt.pak3nuh.hollywood.processor.generator.mirror
+
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.asTypeName
+import pt.pak3nuh.hollywood.actor.proxy.ProxyConfiguration
+import pt.pak3nuh.hollywood.processor.Actor
+import pt.pak3nuh.hollywood.processor.generator.FileGenerator
+import pt.pak3nuh.hollywood.processor.generator.MethodResult
+import pt.pak3nuh.hollywood.processor.generator.SourceFile
+import pt.pak3nuh.hollywood.processor.generator.TypeResult
+import pt.pak3nuh.hollywood.processor.generator.context.GenerationContext
+import pt.pak3nuh.hollywood.processor.generator.context.generationAnnotation
+import pt.pak3nuh.hollywood.processor.generator.mirror.visitor.TypeElementVisitor
+import pt.pak3nuh.hollywood.processor.generator.util.proxyName
+import javax.lang.model.element.ElementKind
+import javax.lang.model.element.TypeElement
+import javax.lang.model.type.TypeMirror
+
+abstract class ProxyClassGenerator: FileGenerator, TypeElementVisitor() {
+
+    final override fun generate(element: TypeElement, context: GenerationContext): SourceFile {
+        require(element.kind == ElementKind.INTERFACE) {
+            "Actor annotation can only be used on interfaces"
+        }
+        return visitType(element, context).toSourceFile()
+    }
+
+    final override fun visitType(typeElement: TypeElement, context: GenerationContext): TypeResult {
+        val actorInterface = typeElement.asType().asTypeName()
+
+        val newClassName = ClassName.bestGuess(proxyName(actorInterface.toString()))
+        val parameterizedProxy = getProxyBaseClass(typeElement, context.typeUtil).parameterizedBy(actorInterface)
+
+        val delegateParam = ParameterSpec.builder("delegate", actorInterface).build()
+        val configParam = ParameterSpec.builder("config", ProxyConfiguration::class.asTypeName()).build()
+
+        val ctr = FunSpec
+                .constructorBuilder()
+                .addParameter(delegateParam)
+                .addParameter(configParam)
+                .build()
+
+        val classBuilder = TypeSpec.classBuilder(newClassName)
+                .addAnnotation(context.generationAnnotation())
+                .primaryConstructor(ctr)
+                .superclass(parameterizedProxy)
+                .addSuperclassConstructorParameter(delegateParam.name)
+                .addSuperclassConstructorParameter(configParam.name)
+                .addSuperinterface(actorInterface)
+
+        val functions = buildFunctions(typeElement, context)
+        classBuilder.addFunctions(functions.map { it.funSpec })
+
+        return TypeResult(newClassName, classBuilder.build())
+    }
+
+    abstract fun buildFunctions(typeElement: TypeElement, context: GenerationContext): List<MethodResult>
+
+    private fun getProxyBaseClass(e: TypeElement, typeUtil: TypeUtil): ClassName {
+        val annotationValue = e.annotationMirrors.asSequence()
+                .filter { it.annotationType.toString() == Actor::class.qualifiedName }
+                .flatMap { annotation ->
+                    typeUtil.getElementValuesWithDefaults(annotation).filterKeys { key ->
+                        key.simpleName.contentEquals(Actor::value.name)
+                    }.values.asSequence()
+                }.first()
+
+
+        val value = annotationValue.value as TypeMirror
+        require(typeUtil.isValidProxy(value)) { "Type $value is not a valid proxy" }
+
+        return ClassName.bestGuess(value.toString())
+    }
+
+}

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/TypeConverter.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/TypeConverter.kt
@@ -1,4 +1,4 @@
-package pt.pak3nuh.hollywood.processor.generator.types
+package pt.pak3nuh.hollywood.processor.generator.mirror
 
 import com.squareup.kotlinpoet.ARRAY
 import com.squareup.kotlinpoet.BOOLEAN

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/TypeUtil.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/TypeUtil.kt
@@ -1,4 +1,4 @@
-package pt.pak3nuh.hollywood.processor.generator.types
+package pt.pak3nuh.hollywood.processor.generator.mirror
 
 import com.squareup.kotlinpoet.TypeName
 import pt.pak3nuh.hollywood.actor.proxy.ActorProxyBase

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/TypeUtil.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/TypeUtil.kt
@@ -24,6 +24,11 @@ interface TypeUtil {
     val coroutineJvmReturnType: TypeMirror
 
     /**
+     * [Nothing] type mirror.
+     */
+    val nothingType: TypeMirror
+
+    /**
      * [Unit] type mirror.
      */
     val unitType: TypeMirror
@@ -62,6 +67,8 @@ class TypeUtilImpl(
      * Type returned at the bytecode level
      */
     override val coroutineJvmReturnType: TypeMirror = objectType
+
+    override val nothingType = getTypeMirror(Nothing::class.java)
 
     override val unitType = getTypeMirror(Unit::class.java)
 

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/TypeUtil.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/TypeUtil.kt
@@ -46,6 +46,13 @@ interface TypeUtil {
     fun convert(element: Element): TypeName = convert(element.asType())
     fun isValidProxy(typeMirror: TypeMirror): Boolean
     fun isActor(typeMirror: TypeMirror): Boolean
+
+    /**
+     * Gets an elements given its name.
+     *
+     * @return The element or null if doesn't exist.
+     */
+    fun getElement(typeName: String): TypeElement?
 }
 
 class TypeUtilImpl(
@@ -73,6 +80,10 @@ class TypeUtilImpl(
     override val unitType = getTypeMirror(Unit::class.java)
 
     override val metadataType: TypeElement = elements.getTypeElement(Metadata::class.qualifiedName)
+
+    override fun getElement(typeName: String): TypeElement? {
+        return elements.getTypeElement(typeName)
+    }
 
     private val customProxy: TypeMirror = getTypeMirror(ActorProxyBase::class.java)
 

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/package-info.java
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package for java mirror based generators.
+ */
+package pt.pak3nuh.hollywood.processor.generator.mirror;

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/visitor/MethodElementVisitor.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/visitor/MethodElementVisitor.kt
@@ -1,4 +1,4 @@
-package pt.pak3nuh.hollywood.processor.visitor
+package pt.pak3nuh.hollywood.processor.generator.mirror.visitor
 
 import pt.pak3nuh.hollywood.processor.generator.NoOpResult
 import pt.pak3nuh.hollywood.processor.generator.Result

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/visitor/TypeElementVisitor.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/mirror/visitor/TypeElementVisitor.kt
@@ -1,4 +1,4 @@
-package pt.pak3nuh.hollywood.processor.visitor
+package pt.pak3nuh.hollywood.processor.generator.mirror.visitor
 
 import pt.pak3nuh.hollywood.processor.generator.NoOpResult
 import pt.pak3nuh.hollywood.processor.generator.Result

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/types/KotlinMetadata.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/types/KotlinMetadata.kt
@@ -1,0 +1,108 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package pt.pak3nuh.hollywood.processor.generator.types
+
+import kotlinx.metadata.KmClass
+import kotlinx.metadata.jvm.KotlinClassHeader
+import kotlinx.metadata.jvm.KotlinClassMetadata
+import pt.pak3nuh.hollywood.processor.generator.context.Property
+import javax.lang.model.element.AnnotationMirror
+import javax.lang.model.element.AnnotationValue
+import javax.lang.model.element.TypeElement
+
+interface KotlinMetadata {
+    companion object Key : Property<KotlinMetadata>
+}
+
+class KotlinMetadataExtractor(
+        private val metadataType: TypeElement
+) {
+
+    fun extract(typeElement: TypeElement): KotlinMetadata {
+        val metadataAnnotation = typeElement.annotationMirrors.first { it.annotationType.asElement() == metadataType }
+        val header = convertHeader(metadataAnnotation)
+        val metadata = KotlinClassMetadata.read(header)
+        return if (metadata == null) {
+            UnsupportedMetadata(typeElement)
+        } else {
+            FullKotlinMetadata((metadata as KotlinClassMetadata.Class).toKmClass())
+        }
+    }
+
+    private fun convertHeader(metadataAnnotation: AnnotationMirror): KotlinClassHeader {
+        return KotlinClassHeader(
+                getKind(metadataAnnotation),
+                getMetadataVersion(metadataAnnotation),
+                getBytecodeVersion(metadataAnnotation),
+                getData1(metadataAnnotation),
+                getData2(metadataAnnotation),
+                getExtraString(metadataAnnotation),
+                getPackageName(metadataAnnotation),
+                getExtraInt(metadataAnnotation)
+        )
+    }
+
+    private fun getPackageName(metadataAnnotation: AnnotationMirror): String? {
+        return getData(metadataAnnotation, "pn")?.toString()
+    }
+
+    private fun getExtraString(metadataAnnotation: AnnotationMirror): String? {
+        return getData(metadataAnnotation, "xs")?.toString()
+    }
+
+    private fun getData2(metadataAnnotation: AnnotationMirror): Array<String>? {
+        val data = getData(metadataAnnotation, "d2")
+        return asStringArray(data)
+    }
+
+    private fun getData1(metadataAnnotation: AnnotationMirror): Array<String>? {
+        val data = getData(metadataAnnotation, "d1")
+        return asStringArray(data)
+    }
+
+    private fun getBytecodeVersion(metadataAnnotation: AnnotationMirror): IntArray? {
+        val data = getData(metadataAnnotation, "bv")
+        return asIntArray(data)
+    }
+
+    private fun getMetadataVersion(metadataAnnotation: AnnotationMirror): IntArray? {
+        val data = getData(metadataAnnotation, "mv")
+        return asIntArray(data)
+    }
+
+    private fun asStringArray(data: Any?): Array<String>? {
+        val list = data as List<AnnotationValue>?
+        return list?.map { it.value as String }?.toTypedArray()
+    }
+
+    private fun asIntArray(data: Any?): IntArray? {
+        val list = data as List<AnnotationValue>?
+        return list?.map { it.value as Int }?.toIntArray()
+    }
+
+    private fun getExtraInt(metadataAnnotation: AnnotationMirror): Int? {
+        return getData(metadataAnnotation, "xi") as Int?
+    }
+
+    private fun getKind(metadataAnnotation: AnnotationMirror): Int? {
+        return getData(metadataAnnotation, "k") as Int?
+    }
+
+    /**
+     * Obtains the value of the annotation member. The actual type is not what is on the source code,
+     * but a mirror based projection over it. Details on [AnnotationValue].
+     */
+    private fun getData(metadataAnnotation: AnnotationMirror, name: String): Any? {
+        val annotationValue = metadataAnnotation.elementValues
+                .asSequence()
+                .firstOrNull { it.key.simpleName.toString() == name }
+                ?.value
+
+        return annotationValue?.value
+    }
+
+}
+
+class FullKotlinMetadata(val metadata: KmClass): KotlinMetadata
+
+class UnsupportedMetadata(val typeElement: TypeElement) : KotlinMetadata

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/types/TypeUtil.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/types/TypeUtil.kt
@@ -18,8 +18,20 @@ import kotlin.coroutines.Continuation
 
 interface TypeUtil {
 
+    /**
+     * [Continuation] type mirror.
+     */
     val coroutineJvmReturnType: TypeMirror
+
+    /**
+     * [Unit] type mirror.
+     */
     val unitType: TypeMirror
+
+    /**
+     * [Metadata] type element.
+     */
+    val metadataType: TypeElement
 
     fun isAssignable(t1: TypeMirror, t2: TypeMirror): Boolean
     fun isAssignableCoroutine(typeMirror: TypeMirror): Boolean
@@ -52,6 +64,8 @@ class TypeUtilImpl(
     override val coroutineJvmReturnType: TypeMirror = objectType
 
     override val unitType = getTypeMirror(Unit::class.java)
+
+    override val metadataType: TypeElement = elements.getTypeElement(Metadata::class.qualifiedName)
 
     private val customProxy: TypeMirror = getTypeMirror(ActorProxyBase::class.java)
 

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/util/Names.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/util/Names.kt
@@ -1,0 +1,3 @@
+package pt.pak3nuh.hollywood.processor.generator.util
+
+fun proxyName(actorName: String) = "${actorName}Proxy"

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/util/TypeChecker.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/util/TypeChecker.kt
@@ -59,7 +59,8 @@ private class TypeCheckerImpl(
         val firstArgument = asDeclared.typeArguments.first()
         val argumentWildcard = firstArgument as WildcardType
 
-        return argumentWildcard.superBound
+        val superBound: TypeMirror? = argumentWildcard.superBound
+        return superBound ?: typeUtil.nothingType
     }
 
     override fun checkIsSuspend(metadata: MetaFun): MetaType {

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/util/TypeChecker.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/util/TypeChecker.kt
@@ -1,6 +1,5 @@
 package pt.pak3nuh.hollywood.processor.generator.util
 
-import pt.pak3nuh.hollywood.processor.Actor
 import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaFun
 import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaType
 import pt.pak3nuh.hollywood.processor.generator.mirror.TypeUtil
@@ -38,7 +37,15 @@ private class TypeCheckerImpl(
     }
 
     override fun checkNotActor(type: MetaType) {
-        check(!type.hasAnnotation(Actor::class)) { NOT_ACTOR }
+        val typeName = type.name
+        val element = typeUtil.getElement(typeName)
+        val isActor = if (null == element) {
+            // unknown element, most likely a flexible kotlin type (platform)
+            false
+        } else {
+            typeUtil.isActor(element.asType())
+        }
+        check(!isActor) { NOT_ACTOR }
     }
 
     override fun checkIsSuspend(parameters: Iterable<VariableElement>, returnType: TypeMirror): TypeMirror {

--- a/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/util/TypeChecker.kt
+++ b/processor/processor-core/src/main/kotlin/pt/pak3nuh/hollywood/processor/generator/util/TypeChecker.kt
@@ -1,0 +1,69 @@
+package pt.pak3nuh.hollywood.processor.generator.util
+
+import pt.pak3nuh.hollywood.processor.Actor
+import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaFun
+import pt.pak3nuh.hollywood.processor.generator.metadata.type.MetaType
+import pt.pak3nuh.hollywood.processor.generator.mirror.TypeUtil
+import javax.lang.model.element.VariableElement
+import javax.lang.model.type.DeclaredType
+import javax.lang.model.type.TypeMirror
+import javax.lang.model.type.WildcardType
+
+interface TypeChecker {
+    fun checkNotActor(variableType: TypeMirror)
+    fun checkNotActor(type: MetaType)
+
+    /**
+     * @return The return type
+     */
+    fun checkIsSuspend(parameters: Iterable<VariableElement>, returnType: TypeMirror): TypeMirror
+    /**
+     * @return The return type
+     */
+    fun checkIsSuspend(metadata: MetaFun): MetaType
+}
+
+@Suppress("FunctionName")
+fun TypeChecker(typeUtil: TypeUtil): TypeChecker = TypeCheckerImpl(typeUtil)
+
+private const val NOT_SUSPENDABLE = "Function not suspendable"
+private const val NOT_ACTOR = "Actors aren't allowed on parameters nor return types"
+
+private class TypeCheckerImpl(
+        private val typeUtil: TypeUtil
+): TypeChecker {
+
+    override fun checkNotActor(variableType: TypeMirror) {
+        check(!typeUtil.isActor(variableType)) { NOT_ACTOR }
+    }
+
+    override fun checkNotActor(type: MetaType) {
+        check(!type.hasAnnotation(Actor::class)) { NOT_ACTOR }
+    }
+
+    override fun checkIsSuspend(parameters: Iterable<VariableElement>, returnType: TypeMirror): TypeMirror {
+        // something like nullable Continuation<? super type>
+        val continuationParameter = parameters.asSequence()
+                .mapIndexed { idx, p -> p.asType() to idx }
+                .sortedByDescending {
+                    // usually is the last parameter
+                    it.second
+                }
+                .firstOrNull { typeUtil.isAssignableCoroutine(it.first) }
+                ?.first
+
+        checkNotNull(continuationParameter) { "Suspending functions must have a Continuation parameter" }
+        check(typeUtil.isAssignable(returnType, typeUtil.coroutineJvmReturnType)) { NOT_SUSPENDABLE }
+
+        val asDeclared = continuationParameter as DeclaredType
+        val firstArgument = asDeclared.typeArguments.first()
+        val argumentWildcard = firstArgument as WildcardType
+
+        return argumentWildcard.superBound
+    }
+
+    override fun checkIsSuspend(metadata: MetaFun): MetaType {
+        check(metadata.isSuspend) { NOT_SUSPENDABLE }
+        return metadata.returnType
+    }
+}

--- a/processor/processor-core/src/test/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGeneratorTest.kt
+++ b/processor/processor-core/src/test/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGeneratorTest.kt
@@ -8,7 +8,7 @@ import javax.lang.model.element.ElementKind
 internal class ActorProxyGeneratorTest {
     @Test
     internal fun `should only accept interfaces`() {
-        val generator = ActorProxyGenerator(mockk())
+        val generator = ActorProxyGenerator(mockk(), mockk())
         assertThrows<IllegalArgumentException> {
             generator.generate(TypeElementStub(ElementKind.ANNOTATION_TYPE), mockk())
         }

--- a/processor/processor-core/src/test/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGeneratorTest.kt
+++ b/processor/processor-core/src/test/kotlin/pt/pak3nuh/hollywood/processor/generator/ActorProxyGeneratorTest.kt
@@ -8,7 +8,7 @@ import javax.lang.model.element.ElementKind
 internal class ActorProxyGeneratorTest {
     @Test
     internal fun `should only accept interfaces`() {
-        val generator = ActorProxyGenerator(mockk(), mockk())
+        val generator = ActorProxyGenerator(mockk(), mockk(), mockk())
         assertThrows<IllegalArgumentException> {
             generator.generate(TypeElementStub(ElementKind.ANNOTATION_TYPE), mockk())
         }


### PR DESCRIPTION
closes #20 
closes #22 

Creates a new generator backed by kotlin metadata annotation. This generator will be used unless the metadata isn't available or is disabled explicitly.
When metadata isn't available, some features are not supported like actor signatures with nullable types.