### PR TITLE
fix HWD-000 Abstracts exception stack traces

### DIFF
--- a/api/src/main/kotlin/pt/pak3nuh/hollywood/actor/message/ReturnValue.kt
+++ b/api/src/main/kotlin/pt/pak3nuh/hollywood/actor/message/ReturnValue.kt
@@ -21,7 +21,24 @@ data class ValueReturn(val value: Any?): ReturnValue()
 data class ExceptionReturn(
         val klass: Class<out Exception>,
         val message: String?,
-        val stackTrace: List<StackTraceElement>?
+        val stackTrace: List<StackElement>?
 ): ReturnValue() {
-    constructor(exception: Exception): this(exception::class.java, exception.message, exception.stackTrace?.toList())
+    constructor(exception: Exception):
+            this(exception::class.java, exception.message, exception.stackTrace?.map(::mapStackElement))
 }
+
+/**
+ * Class to model stacktrace lines. I don't use [StackTraceElement] because it differs starting on JDK9+.
+ *
+ * Multi-release jar was considered, but adds accidental complexity on the build process.
+ */
+data class StackElement(val className: String, val methodName: String, val fileName: String?, val lineNumber: Int) {
+    fun toJdkStackElement() = StackTraceElement(className, methodName, fileName, lineNumber)
+}
+
+fun mapStackElement(jdkElement: StackTraceElement): StackElement = StackElement(
+        jdkElement.className,
+        jdkElement.methodName,
+        jdkElement.fileName,
+        jdkElement.lineNumber
+)

--- a/api/src/main/kotlin/pt/pak3nuh/hollywood/actor/proxy/ActorProxyBase.kt
+++ b/api/src/main/kotlin/pt/pak3nuh/hollywood/actor/proxy/ActorProxyBase.kt
@@ -18,6 +18,7 @@ import pt.pak3nuh.hollywood.actor.message.ReferenceParameter
 import pt.pak3nuh.hollywood.actor.message.Response
 import pt.pak3nuh.hollywood.actor.message.ReturnType
 import pt.pak3nuh.hollywood.actor.message.ShortParameter
+import pt.pak3nuh.hollywood.actor.message.StackElement
 import pt.pak3nuh.hollywood.actor.message.UnitResponse
 import pt.pak3nuh.hollywood.actor.message.ValueResponse
 import pt.pak3nuh.hollywood.actor.message.ValueReturn
@@ -187,4 +188,11 @@ private class MsgParamsImpl(private val message: Message) : MsgParams {
 }
 
 class ProxyRequestException(message: String?) : RuntimeException(message)
-class ProxyResponseException(message: String?, stackTrace: List<StackTraceElement>?) : RuntimeException(message)
+class ProxyResponseException(
+        message: String?,
+        private val stackTrace: List<StackElement>?
+) : RuntimeException(message) {
+    override fun getStackTrace(): Array<StackTraceElement> {
+        return stackTrace?.map(StackElement::toJdkStackElement)?.toTypedArray() ?: emptyArray()
+    }
+}

--- a/core/src/main/kotlin/pt/pak3nuh/hollywood/system/actor/message/serializer/externalizable/ExternalizableMessages.kt
+++ b/core/src/main/kotlin/pt/pak3nuh/hollywood/system/actor/message/serializer/externalizable/ExternalizableMessages.kt
@@ -16,6 +16,7 @@ import pt.pak3nuh.hollywood.actor.message.ReferenceParameter
 import pt.pak3nuh.hollywood.actor.message.Response
 import pt.pak3nuh.hollywood.actor.message.ReturnType
 import pt.pak3nuh.hollywood.actor.message.ShortParameter
+import pt.pak3nuh.hollywood.actor.message.StackElement
 import pt.pak3nuh.hollywood.actor.message.UnitResponse
 import pt.pak3nuh.hollywood.actor.message.ValueResponse
 import pt.pak3nuh.hollywood.actor.message.ValueReturn
@@ -191,7 +192,7 @@ class ExternalizableResponse() : Externalizable {
                 val message: String? = input.readUTF().orNull()
                 val stackSize = input.readInt()
                 val stackTrace = (0 until stackSize).map {
-                    StackTraceElement(
+                    StackElement(
                             input.readUTF(), //className
                             input.readUTF(), //methodName
                             input.readUTF().orNull(), //fileName

--- a/core/src/main/kotlin/pt/pak3nuh/hollywood/system/actor/message/serializer/externalizable/ExternalizableSerDes.kt
+++ b/core/src/main/kotlin/pt/pak3nuh/hollywood/system/actor/message/serializer/externalizable/ExternalizableSerDes.kt
@@ -21,6 +21,13 @@ import java.io.ObjectInputStream
 import java.io.ObjectOutputStream
 import java.io.OutputStream
 
+/**
+ * Serdes for classes marked as [Externalizable].
+ *
+ * This is the only serializer that will process [ReturnType.UNIT] and [ReturnType.EXCEPTION]
+ * for efficiency reasons. Since the format is static, this serializer should be the one that produces
+ * less boilerplate.
+ */
 class ExternalizableSerDes : InternalSerDes {
 
     fun serialize(message: Message): ByteArray {
@@ -60,7 +67,7 @@ class ExternalizableSerDes : InternalSerDes {
     }
 
     override fun supports(response: Response): Boolean {
-        // only this serializer supports unit and return types because the format is static
+        // only this serializer supports unit and exception return types because the format is static
         return when (response.returnType) {
             ReturnType.UNIT, ReturnType.EXCEPTION -> true
             ReturnType.VALUE -> isValueExternalizable((response.returnValue as ValueReturn).value)

--- a/core/src/test/kotlin/pt/pak3nuh/hollywood/system/actor/message/serializer/LateBindStrategyTest.kt
+++ b/core/src/test/kotlin/pt/pak3nuh/hollywood/system/actor/message/serializer/LateBindStrategyTest.kt
@@ -11,10 +11,12 @@ import pt.pak3nuh.hollywood.actor.message.ExceptionResponse
 import pt.pak3nuh.hollywood.actor.message.ExceptionReturn
 
 import pt.pak3nuh.hollywood.actor.message.ReturnType
+import pt.pak3nuh.hollywood.actor.message.StackElement
 import pt.pak3nuh.hollywood.actor.message.UnitResponse
 import pt.pak3nuh.hollywood.actor.message.UnitReturn
 import pt.pak3nuh.hollywood.actor.message.ValueResponse
 import pt.pak3nuh.hollywood.actor.message.ValueReturn
+import pt.pak3nuh.hollywood.actor.message.mapStackElement
 import pt.pak3nuh.hollywood.system.actor.message.MessageBuilderImpl
 import pt.pak3nuh.hollywood.system.actor.message.serializer.externalizable.ExternalizableSerDes
 import pt.pak3nuh.hollywood.system.actor.message.serializer.kotlin.KSerDesHolder
@@ -65,7 +67,7 @@ internal class LateBindStrategyTest {
         assertThat(response.returnValue).isInstanceOf(ExceptionReturn::class)
                 .all {
                     transform { it.message }.isEqualTo(exception.message)
-                    transform { it.stackTrace }.isEqualTo(exception.stackTrace?.toList())
+                    transform { it.stackTrace }.isEqualTo(exception.stackTrace?.map(::mapStackElement))
                 }
     }
 


### PR DESCRIPTION
StackTraceElement classes have different shape from JDK9+ and it causes
equals comparisons to fail.
Abstracts these elements so that comparisons can be done on a fixed structure.